### PR TITLE
Installation support for darwin

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,10 +3,24 @@
     {
       "target_name": "notify",
       "sources": [
-        "notify.cc"
+        "notify.cc",
+        "noop.cc"
       ],
       "libraries": [
         "-lsystemd"
+      ],
+      'conditions': [
+        ['OS!="linux"',
+          {
+            'sources/': [['exclude', 'notify.cc$']],
+            'libraries/': [['exclude', '-lsystemd$']],
+          }
+        ],
+        ['OS=="linux"',
+          {
+            'sources/': [['exclude', 'noop.cc$']]
+          }
+        ]
       ]
     }
   ]

--- a/noop.cc
+++ b/noop.cc
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 - 2018, Rory Bradford <roryrjb@gmail.com> and contributors
+// MIT License
+
+#include <node.h>
+
+namespace notify {
+
+void ready(const v8::FunctionCallbackInfo<v8::Value>& args) {}
+
+void stopping(const v8::FunctionCallbackInfo<v8::Value>& args) {}
+
+void watchdog(const v8::FunctionCallbackInfo<v8::Value>& args) {}
+
+void sendstate(const v8::FunctionCallbackInfo<v8::Value>& args) {}
+
+void interval(const v8::FunctionCallbackInfo<v8::Value>& args) {}
+
+void journal_print(const v8::FunctionCallbackInfo<v8::Value>& args) {}
+
+}  // namespace notify
+
+void Init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "ready", notify::ready);
+  NODE_SET_METHOD(exports, "stopping", notify::stopping);
+  NODE_SET_METHOD(exports, "watchdog", notify::watchdog);
+  NODE_SET_METHOD(exports, "watchdogInterval", notify::interval);
+  NODE_SET_METHOD(exports, "sendState", notify::sendstate);
+  NODE_SET_METHOD(exports, "journalPrint", notify::journal_print);
+}
+
+NODE_MODULE(addon, Init)
+

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "standard": "=12.0.1"
   },
   "os": [
-    "linux"
+    "linux",
+    "darwin"
   ]
 }


### PR DESCRIPTION
Many people (myself included) develop on macOS and deploy in a linux environment. By allowing the package to be installed on macOS, one can keep their `package.json` and lock file committed and the same for both environments.

This fork adds a noop.cc that stubs out the mandatory functions. `binding.gyp` conditionals say whether to use notify.cc or noop.cc based on OS platform.